### PR TITLE
Make directory creation operations idempotent

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,7 @@ class storm::install inherits storm {
     command => "mkdir -p ${local_dir}",
     path    => ['/bin', '/sbin'],
     require => Package['storm'],
+    creates => $local_dir
   }
   ->
   file { $local_dir:
@@ -34,6 +35,7 @@ class storm::install inherits storm {
       command => "mkdir -p ${log_dir}",
       path    => ['/bin', '/sbin'],
       require => Package['storm'],
+      creates => $Log_dir
     }
     ->
     file { $log_dir:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,7 @@ class storm::install inherits storm {
       command => "mkdir -p ${log_dir}",
       path    => ['/bin', '/sbin'],
       require => Package['storm'],
-      creates => $Log_dir
+      creates => $log_dir
     }
     ->
     file { $log_dir:


### PR DESCRIPTION
The execs that create directories should only run if the directory does not already exist.